### PR TITLE
Fix state version in NixOS config

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -135,6 +135,6 @@
   # this value at the release version of the first install of this system.
   # Before changing this value read the documentation for this option
   # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
-  system.stateVersion = "25.05"; # Did you read the comment?
+  system.stateVersion = "24.05"; # Did you read the comment?
 
 }


### PR DESCRIPTION
## Summary
- correct the NixOS `system.stateVersion` setting

## Testing
- `nix-instantiate --parse configuration.nix` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d842398288322be5d4419942ff291