### PR TITLE
Switch to GNOME and enable Flatpak BibleTime

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -45,9 +45,9 @@
   # Enable the X11 windowing system.
   services.xserver.enable = true;
 
-  # Enable the Pantheon Desktop Environment.
-  services.xserver.displayManager.lightdm.enable = true;
-  services.xserver.desktopManager.pantheon.enable = true;
+  # Enable the GNOME Desktop Environment.
+  services.xserver.displayManager.gdm.enable = true;
+  services.xserver.desktopManager.gnome.enable = true;
 
   # Configure keymap in X11
   services.xserver.xkb = {
@@ -57,6 +57,15 @@
 
   # Enable CUPS to print documents.
   services.printing.enable = true;
+
+  # Enable Flatpak and desktop portals.
+  xdg.portal.enable = true;
+  services.flatpak.enable = true;
+
+  system.activationScripts.installBibletime.text = ''
+    ${pkgs.flatpak}/bin/flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+    ${pkgs.flatpak}/bin/flatpak install -y --noninteractive flathub org.kde.bibletime
+  '';
 
   # Enable sound with pipewire.
   services.pulseaudio.enable = false;


### PR DESCRIPTION
## Summary
- switch from Pantheon to GNOME
- enable Flatpak with XDG portal
- install BibleTime from Flathub on activation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d8453e07c83229c85c2eae4ea032f